### PR TITLE
Fe/navbar

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -1,0 +1,11 @@
+---
+glob: "**/*.erb"
+linters:
+  FinalNewline:
+    enabled: true
+  SpaceAroundErbTag:
+    enabled: true
+  NoUnusedDisable:
+    enabled: true
+  RequireInputAutocomplete:
+    enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ group :development do
 
   # Static type checking [https://sorbet.org/]
   gem "sorbet"
+
+  # Static analysis for ERB templates [https://github.com/Shopify/erb_lint]
+  gem "erb_lint"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,13 @@ GEM
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.9)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -107,6 +114,13 @@ GEM
     dotenv (3.1.7)
     drb (2.2.1)
     ed25519 (1.3.0)
+    erb_lint (0.9.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -330,6 +344,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     solid_cable (3.0.7)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -442,6 +457,7 @@ DEPENDENCIES
   capybara
   dartsass-rails (~> 0.5.1)
   debug
+  erb_lint
   importmap-rails
   jbuilder
   kamal

--- a/app/assets/stylesheets/components/_banner_search.scss
+++ b/app/assets/stylesheets/components/_banner_search.scss
@@ -1,4 +1,5 @@
 @use "../colors/color_variables";
+@use "../typography/typography";
 
 // 최상단 검색바 컨테이너
 .search-bar {
@@ -14,12 +15,10 @@
   box-sizing: border-box; 
   
   input[type="text"] {
+    @extend .body-large; 
     border: none;
     width: 660px;
     height: 41px;
-    font-weight: 400;
-    font-size: 24px; 
-    line-height: 150%; 
     vertical-align: middle; 
   }
       

--- a/app/assets/stylesheets/components/_bill_table.scss
+++ b/app/assets/stylesheets/components/_bill_table.scss
@@ -1,4 +1,5 @@
 @use "../colors/color_variables";
+@use "../typography/typography";
 
 // 법안 카드 컨테이너 스타일
 .bill-card-container {
@@ -31,11 +32,9 @@
  
 // 법안 헤더 제목 스타일
 .bill-title {
+    @extend .title-small; 
     color: color_variables.$text-primary-color;
     flex: 1;
-
-    font-size: 30px;
-    font-weight: 600;
 }
 
 // 법안 헤더 태그 스타일
@@ -47,33 +46,28 @@
  
 // 법안 태그 정당 스타일
 .bill-tag-party {
+    @extend .button-small;
     width: 125;
     height: 25;
     padding: 1px 33px;
     background-color: color_variables.$background-primary-color;
     text-align: center;
     border-radius: 10px;
-
-    font-weight: 400;
-    font-size: 16px;
 }
  
 // 법안 태그 상태 스타일
 .bill-tag-status {
+    @extend .button-small;
     padding: 1px 18px;
     background-color: color_variables.$background-primary-color;
     text-align: center;
     width: 65;
     height: 25;
     border-radius: 10px;
-
-    font-weight: 400;
-    font-size: 16px;
 }
 
 // 법안 상세정보 스타일
 .bill-description {
-    font-size: 24px;
-    font-weight: 400;
+    @extend .body-large;
 }
   

--- a/app/assets/stylesheets/components/_law_categories.scss
+++ b/app/assets/stylesheets/components/_law_categories.scss
@@ -1,5 +1,6 @@
 @use "../colors/color_variables";
 
+// 법안 카테고리 컴포넌트 스타일
 $law-components: (
     government-administration-comp: 227px,
     legislative-judicial-comp: 227px,
@@ -24,8 +25,6 @@ $law-components: (
     align-content: center;
     flex-wrap: wrap;
     gap: 10px;
-
-    background: color_variables.$background-primary-color;
 }
 
 // 공통 스타일 정의

--- a/app/assets/stylesheets/components/_political_party.scss
+++ b/app/assets/stylesheets/components/_political_party.scss
@@ -1,21 +1,6 @@
 @use "../colors/color_variables";
 @use "../typography/typography.scss" as typography;
 
-.political-component-layer {
-    display: flex;
-    width: 148px;
-    height: 193px;
-    border-radius: 5px; 
-    border-width: 1px;
-
-    align-items: center;
-    align-content: center;
-    flex-wrap: wrap;
-    gap: 10px;
-
-    background: color_variables.$background-primary-color;
-}
-
 %political-common-shape-component {
     width: 108px;
     height: 35px;

--- a/app/assets/stylesheets/typography/_political_party_typography.scss
+++ b/app/assets/stylesheets/typography/_political_party_typography.scss
@@ -1,23 +1,17 @@
 @use "../colors/color_variables";
-@use "../typography/typography.scss" as typography;
+@use "../typography/typography";
 
-%political-common-text-component {
-    @extend .button-small;  // button-small을 확장
-    text-align: center;
-    letter-spacing: -0.64px;
-}
-
-// 정당 관련 텍스트 컴포넌트의 이름과 색상 맵
+// 정당별 폰트 색상 매핑
 $political-text-components-color: (
     democratic-party-text: #152484,
     people-power-text: #E61E2B,
     rebuilding-korea-text: #0073CF
 );
 
-// 각 텍스트 컴포넌트의 스타일을 자동으로 생성
+// 정당 텍스트 컴포넌트 스타일
 @each $name, $color in $political-text-components-color {
     .#{$name} {
-        @extend %political-common-text-component;
+        @extend .button-small;
         color: $color;
     }
 }

--- a/app/assets/stylesheets/typography/typography.scss
+++ b/app/assets/stylesheets/typography/typography.scss
@@ -1,123 +1,103 @@
 // 텍스트 스타일 변수 설정
-$font-family-base: "Pretendard GOV", sans-serif;// 기본 폰트
 
-$headline-large-font-size: 60px; 
-$headline-medium-font-size: 54px; 
-$title-large-font-size: 40px;
-$title-medium-font-size: 34px;
-$title-small-font-size: 30px;
-$body-large-font-size: 24px;
-$body-medium-font-size: 20px;
-$body-small-font-size: 18px;
-$button-medium-font-size: 18px;
-$button-small-font-size: 16px;
-$caption-medium-font-size: 14px;
-$caption-small-font-size: 12px;
+// 기본 속성
+$font-family-base: "Pretendard GOV";    // 기본 폰트
+$line-height: 1.5;                      // 150%
+$letter-spacing: -0.04em;               // -4% 자간
 
-$semibold-font-weight: 600; // SemiBold
-$medium-font-weight: 500; // Medium
-$regular-font-weight: 400; // Regular
-$light-font-weight: 300; // Light
+// 폰트 크기
+$font-sizes: (
+  "headline-large": 60px,
+  "headline-medium": 54px,
+  "title-large": 40px,
+  "title-medium": 34px,
+  "title-small": 30px,
+  "body-large": 24px,
+  "body-medium": 20px,
+  "body-small": 18px,
+  "button-medium": 18px,
+  "button-small": 16px,
+  "caption-medium": 14px,
+  "caption-small": 12px
+);
 
-$line-height: 1.5; // 150%
-$letter-spacing: -0.04em; // -4% 자간
+// 폰트 두께
+$font-weights: (
+  "semibold": 600,
+  "medium": 500,
+  "regular": 400,
+  "light": 300
+);
 
-// Headline L 스타일
-.headline-large {
+// 타이포그래피 타입별 폰트 두께 매핑
+$type-weights: (
+  "headline": map-get($font-weights, "semibold"),
+  "title": map-get($font-weights, "medium"),
+  "body": map-get($font-weights, "regular"),
+  "button": map-get($font-weights, "medium"),
+  "caption": map-get($font-weights, "light")
+);
+
+// 타이포그래피 스타일 mixin
+@mixin typography($type, $size) {
+  // 기본 속성
   font-family: $font-family-base;
-  font-size: $headline-large-font-size;
-  font-weight: $semibold-font-weight;
   line-height: $line-height;
   letter-spacing: $letter-spacing;
+  
+  // 폰트 크기 설정
+  $key: "#{$type}-#{$size}";
+  font-size: map-get($font-sizes, $key);
+  
+  // 폰트 두께 설정
+  font-weight: map-get($type-weights, $type);
 }
 
-// Headline M 스타일
+// 각 타이포그래피 클래스
+.headline-large {
+  @include typography("headline", "large");
+}
+
 .headline-medium {
-  font-family: $font-family-base;
-  font-size: $headline-medium-font-size;
-  font-weight: $semibold-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("headline", "medium");
 }
 
 .title-large {
-  font-family: $font-family-base;
-  font-size: $title-large-font-size;
-  font-weight: $medium-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("title", "large");
 }
 
 .title-medium {
-  font-family: $font-family-base;
-  font-size: $title-medium-font-size;
-  font-weight: $medium-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("title", "medium");
 }
 
 .title-small {
-  font-family: $font-family-base;
-  font-size: $title-small-font-size;
-  font-weight: $medium-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("title", "small");
 }
 
 .body-large {
-  font-family: $font-family-base;
-  font-size: $body-large-font-size;
-  font-weight: $regular-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("body", "large");
 }
 
 .body-medium {
-  font-family: $font-family-base;
-  font-size: $body-medium-font-size;
-  font-weight: $regular-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("body", "medium");
 }
 
 .body-small {
-  font-family: $font-family-base;
-  font-size: $body-small-font-size;
-  font-weight: $regular-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("body", "small");
 }
 
 .button-medium {
-  font-family: $font-family-base;
-  font-size: $button-medium-font-size;
-  font-weight: $medium-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("button", "medium");
 }
 
 .button-small {
-  font-family: $font-family-base;
-  font-size: $button-small-font-size;
-  font-weight: $medium-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("button", "small");
 }
 
 .caption-medium {
-  font-family: $font-family-base;
-  font-size: $caption-medium-font-size;
-  font-weight: $light-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("caption", "medium");
 }
 
 .caption-small {
-  font-family: $font-family-base;
-  font-size: $caption-small-font-size;
-  font-weight: $light-font-weight;
-  line-height: $line-height;
-  letter-spacing: $letter-spacing;
+  @include typography("caption", "small");
 }
-
-

--- a/app/views/bills/_law_categories.html.erb
+++ b/app/views/bills/_law_categories.html.erb
@@ -1,67 +1,67 @@
-<!-- 법안 카테고리 컴포넌튼 -->
+<!-- 법안 카테고리 컴포넌트 -->
 
 <div class="law-component-layer">
-  <%= link_to bills_categories_path(tab: 'government-administration'), class: "government-administration-comp #{'active' if params[:tab] == 'government-administration'}" do %>
+  <%= link_to bills_path(tab: 'government-administration'), class: "government-administration-comp #{'active' if params[:tab] == 'government-administration'}" do %>
     <div class="law-common-text-component">
       🏛 정부·행정과 공공제도
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'legislative-judicial'), class: "legislative-judicial-comp #{'active' if params[:tab] == 'legislative-judicial'}" do %>
+  <%= link_to bills_path(tab: 'legislative-judicial'), class: "legislative-judicial-comp #{'active' if params[:tab] == 'legislative-judicial'}" do %>
     <div class="law-common-text-component">
       ⚖ 입법·사법과 선거제도
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'publicsecurity-nationaldefense'), class: "publicsecurity-nationaldefense-comp #{'active' if params[:tab] == 'publicsecurity-nationaldefense'}" do %>
+  <%= link_to bills_path(tab: 'publicsecurity-nationaldefense'), class: "publicsecurity-nationaldefense-comp #{'active' if params[:tab] == 'publicsecurity-nationaldefense'}" do %>
     <div class="law-common-text-component">
       🚔 치안·사법과 국방
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'economy-finance'), class: "economy-finance-comp #{'active' if params[:tab] == 'economy-finance'}" do %>
+  <%= link_to bills_path(tab: 'economy-finance'), class: "economy-finance-comp #{'active' if params[:tab] == 'economy-finance'}" do %>
     <div class="law-common-text-component">
       💰 경제·재정과 공정거래
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'industry-sciencetechnology'), class: "industry-sciencetechnology-comp #{'active' if params[:tab] == 'industry-sciencetechnology'}" do %>
+  <%= link_to bills_path(tab: 'industry-sciencetechnology'), class: "industry-sciencetechnology-comp #{'active' if params[:tab] == 'industry-sciencetechnology'}" do %>
     <div class="law-common-text-component">
       🔬 산업·과학기술과 정보통신
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'land-urbandevelopment'), class: "land-urbandevelopment-comp #{'active' if params[:tab] == 'land-urbandevelopment'}" do %>
+  <%= link_to bills_path(tab: 'land-urbandevelopment'), class: "land-urbandevelopment-comp #{'active' if params[:tab] == 'land-urbandevelopment'}" do %>
     <div class="law-common-text-component">
       🏗 국토·도시개발과 환경
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'health-welfare'), class: "health-welfare-comp #{'active' if params[:tab] == 'health-welfare'}" do %>
+  <%= link_to bills_path(tab: 'health-welfare'), class: "health-welfare-comp #{'active' if params[:tab] == 'health-welfare'}" do %>
     <div class="law-common-text-component">
       🏥 보건·복지와 안전망
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'education-culture'), class: "education-culture-comp #{'active' if params[:tab] == 'education-culture'}" do %>
+  <%= link_to bills_path(tab: 'education-culture'), class: "education-culture-comp #{'active' if params[:tab] == 'education-culture'}" do %>
     <div class="law-common-text-component">
       🎓 교육·문화와 관광
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'labor-humanrights'), class: "labor-humanrights-comp #{'active' if params[:tab] == 'labor-humanrights'}" do %>
+  <%= link_to bills_path(tab: 'labor-humanrights'), class: "labor-humanrights-comp #{'active' if params[:tab] == 'labor-humanrights'}" do %>
     <div class="law-common-text-component">
       👥 노동·인권과 성평등
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'diplomacy-unification'), class: "diplomacy-unification-comp #{'active' if params[:tab] == 'diplomacy-unification'}" do %>
+  <%= link_to bills_path(tab: 'diplomacy-unification'), class: "diplomacy-unification-comp #{'active' if params[:tab] == 'diplomacy-unification'}" do %>
     <div class="law-common-text-component">
       🌍 외교·통일과 국제협력
     </div>
   <% end %>
 
-  <%= link_to bills_categories_path(tab: 'disaster-climate'), class: "disaster-climate-comp #{'active' if params[:tab] == 'disaster-climate'}" do %>
+  <%= link_to bills_path(tab: 'disaster-climate'), class: "disaster-climate-comp #{'active' if params[:tab] == 'disaster-climate'}" do %>
     <div class="law-common-text-component">
       🆘 재난·기후와 원자력 안전
     </div>

--- a/app/views/bills/_law_categories.html.erb
+++ b/app/views/bills/_law_categories.html.erb
@@ -1,3 +1,5 @@
+<!-- 법안 카테고리 컴포넌튼 -->
+
 <div class="law-component-layer">
   <%= link_to bills_categories_path(tab: 'government-administration'), class: "government-administration-comp #{'active' if params[:tab] == 'government-administration'}" do %>
     <div class="law-common-text-component">
@@ -64,22 +66,4 @@
       🆘 재난·기후와 원자력 안전
     </div>
   <% end %>
-</div>
-
-<div class="political-component-layer">
-  <div class="democratic-party-shape">
-    <div class="democratic-party-text">
-      더불어 민주당
-    </div>
-  </div>
-  <div class="people-power-shape">
-    <div class="people-power-text">
-      국민의 힘
-    </div>
-  </div>
-  <div class="rebuilding-korea-shape">
-    <div class="rebuilding-korea-text">
-      조국혁신당
-    </div>
-  </div>
 </div>

--- a/app/views/bills/_political_party_categories.html.erb
+++ b/app/views/bills/_political_party_categories.html.erb
@@ -1,0 +1,19 @@
+<!-- 정당 컴포넌트 -->
+
+<div class="democratic-party-shape">
+    <div class="democratic-party-text">
+      더불어 민주당
+    </div>
+</div>
+
+<div class="people-power-shape">
+    <div class="people-power-text">
+      국민의 힘
+    </div>
+</div>
+
+<div class="rebuilding-korea-shape">
+    <div class="rebuilding-korea-text">
+      조국혁신당
+    </div>
+</div>

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -1,8 +1,10 @@
 <!-- 상단 배너 검색바 -->
 <%= render "banner_search" %>
+<!-- 법안 카테고리 -->
+<%= render "law_categories" %>
 
 <div class="bill-card-container">
-  <!-- 실제 데이터 
+  <!-- 실제 데이터
   <%# @bills.each do |bill| %>
     <div class="bill-card">
       <div class="bill-header">
@@ -18,7 +20,7 @@
     </div>
   <%# end %>
   -->
-  
+
   <!-- 법안 카드 예시 -->
   <div class="bill-card">
     <!-- 법안 헤더(제목, 태그) -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,6 @@ Rails.application.routes.draw do
     # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
     # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-    if Rails.env.development?
-      get "bills/categories", to: "bills#categories"
-    end
-
     resources :bills, only: [ :index, :show ] do
       # resources :bill_events, only: [ :index, :show ]
     end


### PR DESCRIPTION
## 작업 내용 
- .erb 파일 스타일 일관성을 위한 gem 설치 (erb_lint)
- typography 재사용성을 높이기 위해 typography.scss파일 리팩토링 및 기존 파일에 typo 적용
- 코드 정리 및 구조 개선(사용하지 않는 스타일 코드 삭제, 주석 추가, 마지막줄에 공백줄 추가)

## 배경
- 현재까지 작성된 코드의 품질과 유지보수성 향상을 위해 시스템을 리팩토링했습니다.

## 필수 리뷰어
- @greenstar1151 , @Sumin6872

## 스크린샷
<img width="1470" alt="스크린샷 2025-04-03 오후 1 50 20" src="https://github.com/user-attachments/assets/9fbce3c1-e92e-4765-a7be-7b557bb83f14" />

## 링크
- [erb_lint gem](https://github.com/Shopify/erb_lint)

## 기타 사항
- rubocop을 설치했지만 .erb 파일은 체킹이 안되는 문제가 있더라구요.. .erb파일의 경우 erb_lint gem을 쓰면 좋을 것 같아 해당 gem을 추가해봤습니다. 어떤 방법이 더 좋은진 제가 잘 몰라서, 혹시 다른 좋은 의견있으면 나눠보면 좋을 것 같아요 
- erb_lint 사용법
```
# 프로젝트 루트 디렉토리에서 사용

# 특정 파일 검사
erb_lint [파일 경로]

# 특정 파일 자동 수정
erb_lint --autocorrect [파일 경로]
```

## 체크 리스트
- 

## 희망 리뷰 완료 일  
- **2025-04-03**
