### PR TITLE
[LAWNOW-85] 법안 상세페이지 정보를 지원하기 위한 스키마 및 모델 업데이트

### DIFF
--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,6 +1,7 @@
 class Bill < ApplicationRecord
   has_many :proposals
   has_many :proposers, through: :proposals
+  has_one :bill_detail
   has_one :government_legislation_notice
 
   validates :bill_type, allow_nil: true, inclusion: { in: %w[헌법개정 예산안 결산 법률안 동의안 승인안 결의안 건의안 규칙안 선출안 중요동의 의원징계 윤리심사 의원자격심사 기타안 기타] }

--- a/app/models/bill_detail.rb
+++ b/app/models/bill_detail.rb
@@ -1,0 +1,5 @@
+class BillDetail < ApplicationRecord
+  belongs_to :bill
+
+  validates :bill_id, uniqueness: true
+end

--- a/db/migrate/20250407064733_make_assembly_bill_id_non_null.rb
+++ b/db/migrate/20250407064733_make_assembly_bill_id_non_null.rb
@@ -1,0 +1,5 @@
+class MakeAssemblyBillIdNonNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :bills, :assembly_bill_id, false
+  end
+end

--- a/db/migrate/20250407065051_add_proposed_at_index_to_bills.rb
+++ b/db/migrate/20250407065051_add_proposed_at_index_to_bills.rb
@@ -1,0 +1,5 @@
+class AddProposedAtIndexToBills < ActiveRecord::Migration[8.0]
+  def change
+    add_index :bills, :proposed_at
+  end
+end

--- a/db/migrate/20250407073239_update_bills.rb
+++ b/db/migrate/20250407073239_update_bills.rb
@@ -1,0 +1,7 @@
+class UpdateBills < ActiveRecord::Migration[8.0]
+  def change
+    add_column :bills, :bill_stage, :string, comment: "심사진행상태"
+    add_index :bills, :bill_stage
+    add_column :bills, :committee_name, :string, comment: "소관위원회"
+  end
+end

--- a/db/migrate/20250407081835_add_columns_to_national_assembly_people.rb
+++ b/db/migrate/20250407081835_add_columns_to_national_assembly_people.rb
@@ -1,0 +1,9 @@
+class AddColumnsToNationalAssemblyPeople < ActiveRecord::Migration[8.0]
+  def change
+    add_column :national_assembly_people, :party_name, :string, comment: "소속정당"
+    add_index :national_assembly_people, :party_name
+    add_column :national_assembly_people, :birth_date, :string, comment: "생년월일"
+    add_column :national_assembly_people, :homepage_url, :string, comment: "홈페이지URL"
+    add_column :national_assembly_people, :affiliated_committee, :string, comment: "소속위원회"
+  end
+end

--- a/db/migrate/20250407103917_create_bill_details.rb
+++ b/db/migrate/20250407103917_create_bill_details.rb
@@ -1,0 +1,45 @@
+
+
+class CreateBillDetails < ActiveRecord::Migration[8.0]
+  def change
+    # API 필드 이름과 1:1 매칭
+    # *_xml 필드는 가공을 거치지 않고 XML 형태로 저장
+    create_table :bill_details do |t|
+      t.timestamps
+      # 의안 위원회심사 정보조회 API
+      # http:​​/​/apis​.data​.go​.kr​/9710000​/BillInfoService2​/getBillCommissionExaminationInfo
+      t.string :jurisdiction_examination_xml, comment: "소관위 심사정보 XML"
+      t.string :jurisdiction_meeting_xml, comment: "소관위 회의정보 XML"
+      t.string :proc_examination_xml, comment: "법사위 체계자구심사정보 XML"
+      t.string :proc_meeting_xml, comment: "법사위 회의정보 XML"
+      t.string :comit_examination_xml, comment: "관련위 심사정보 XML"
+      t.string :comit_meeting_xml, comment: "관련위 회의정보 XML"
+
+      # 의안 본회의심의 정보조회 API
+      # http:​​/​/apis​.data​.go​.kr​/9710000​/BillInfoService2​/getBillDeliverateInfo
+      t.string :plenary_session_examination_xml, comment: "본회의 심의정보 XML"
+      t.string :plenary_session_modify_xml, comment: "본회의 수정안 XML"
+      t.string :plenary_session_gov_recon_xml, comment: "정부재의안 XML"
+
+      # 의안 정부이송 정보조회 API
+      # http:​​/​/apis​.data​.go​.kr​/9710000​/BillInfoService2​/getBillTransferredInfo
+      t.datetime :bill_transferred_at, comment: "정부이송일"
+
+      # 의안 공포 정보조회 API
+      # http:​​/​/apis​.data​.go​.kr​/9710000​/BillInfoService2​/getBillPromulgationInfo
+      t.datetime :bill_promulgated_at, comment: "공포일자"
+      t.string :bill_promulgation_number, comment: "공포번호"
+      t.string :law_bon_url, comment: "공포법률 URL"
+      t.string :law_title, comment: "공포법률명"
+
+      # 의안 부가정보 정보조회 API
+      # http:​​/​/apis​.data​.go​.kr​/9710000​/BillInfoService2​/getBillAdditionalInfo
+      t.string :comm_memo_xml, comment: "비고 XML"
+      t.string :exhaust_xml, comment: "대안반영폐기 의안목록 XML"
+      t.string :bill_gbn_cd_xml, comment: "대안 XML"
+
+      # Bill FK
+      t.references :bill, null: false, foreign_key: true, index: { name: "index_bill_details_on_bill_id" }
+    end
+  end
+end

--- a/db/migrate/20250407131117_add_unique_constraint_to_bill_details_bill_id.rb
+++ b/db/migrate/20250407131117_add_unique_constraint_to_bill_details_bill_id.rb
@@ -1,0 +1,9 @@
+class AddUniqueConstraintToBillDetailsBillId < ActiveRecord::Migration[8.0]
+  def change
+    # Remove the existing non-unique index
+    remove_index :bill_details, name: "index_bill_details_on_bill_id", if_exists: true
+
+    # Add a unique index to bill_id
+    add_index :bill_details, :bill_id, unique: true, name: "index_bill_details_on_bill_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_065051) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_073239) do
   create_table "bills", force: :cascade do |t|
     t.string "title", null: false
     t.string "bill_number"
@@ -20,7 +20,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_07_065051) do
     t.string "bill_type"
     t.string "assembly_bill_id", null: false
     t.datetime "proposed_at"
+    t.string "bill_stage"
+    t.string "committee_name"
     t.index ["assembly_bill_id"], name: "index_bills_on_assembly_bill_id", unique: true
+    t.index ["bill_stage"], name: "index_bills_on_bill_stage"
     t.index ["bill_type"], name: "index_bills_on_bill_type"
     t.index ["proposed_at"], name: "index_bills_on_proposed_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_05_083200) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_064733) do
   create_table "bills", force: :cascade do |t|
     t.string "title", null: false
     t.string "bill_number"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_05_083200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "bill_type"
-    t.string "assembly_bill_id"
+    t.string "assembly_bill_id", null: false
     t.datetime "proposed_at"
     t.index ["assembly_bill_id"], name: "index_bills_on_assembly_bill_id", unique: true
     t.index ["bill_type"], name: "index_bills_on_bill_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_081835) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_103917) do
+  create_table "bill_details", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "jurisdiction_examination_xml"
+    t.string "jurisdiction_meeting_xml"
+    t.string "proc_examination_xml"
+    t.string "proc_meeting_xml"
+    t.string "comit_examination_xml"
+    t.string "comit_meeting_xml"
+    t.string "plenary_session_examination_xml"
+    t.string "plenary_session_modify_xml"
+    t.string "plenary_session_gov_recon_xml"
+    t.datetime "bill_transferred_at"
+    t.datetime "bill_promulgated_at"
+    t.string "bill_promulgation_number"
+    t.string "law_bon_url"
+    t.string "law_title"
+    t.string "comm_memo_xml"
+    t.string "exhaust_xml"
+    t.string "bill_gbn_cd_xml"
+    t.integer "bill_id", null: false
+    t.index ["bill_id"], name: "index_bill_details_on_bill_id"
+  end
+
   create_table "bills", force: :cascade do |t|
     t.string "title", null: false
     t.string "bill_number"
@@ -86,6 +110,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_07_081835) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "bill_details", "bills"
   add_foreign_key "government_bill_sponsors", "proposers"
   add_foreign_key "government_legislation_notices", "bills"
   add_foreign_key "national_assembly_people", "proposers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_064733) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_065051) do
   create_table "bills", force: :cascade do |t|
     t.string "title", null: false
     t.string "bill_number"
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_07_064733) do
     t.datetime "proposed_at"
     t.index ["assembly_bill_id"], name: "index_bills_on_assembly_bill_id", unique: true
     t.index ["bill_type"], name: "index_bills_on_bill_type"
+    t.index ["proposed_at"], name: "index_bills_on_proposed_at"
   end
 
   create_table "government_bill_sponsors", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_073239) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_081835) do
   create_table "bills", force: :cascade do |t|
     t.string "title", null: false
     t.string "bill_number"
@@ -62,6 +62,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_07_073239) do
     t.string "photo_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "party_name"
+    t.string "birth_date"
+    t.string "homepage_url"
+    t.string "affiliated_committee"
+    t.index ["party_name"], name: "index_national_assembly_people_on_party_name"
     t.index ["proposer_id"], name: "index_national_assembly_people_on_proposer_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_103917) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_131117) do
   create_table "bill_details", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_07_103917) do
     t.string "exhaust_xml"
     t.string "bill_gbn_cd_xml"
     t.integer "bill_id", null: false
-    t.index ["bill_id"], name: "index_bill_details_on_bill_id"
+    t.index ["bill_id"], name: "index_bill_details_on_bill_id", unique: true
   end
 
   create_table "bills", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,8 @@ if Rails.env.development?
     b.assembly_bill_id = "ARC_O2N5Y0K3V1H9W2Z1F1C2K2U6Q8N7E8"
     b.summary = "제안이유 및 주요내용 지방자치단체 수행 사무에 관한 규범을 지방자치단체가 자기 책임하에 자율적으로 정할 수 있도록 자치입법권을 확대하기 위하여 지방자치단체가 밀원식물(蜜原植物)*의 조성에 필요한 사항을 해당 지방자치단체의 조례로 정할 수 있도록 하려는 것임. * 밀원식물(蜜原植物): 꿀벌이 꽃꿀, 꽃가루와 수액의 수집을 위하여 찾아가는 식물로서 농림축산식품부령으로 정하는 식물"
     b.proposed_at = Date.new(2025, 3, 20)
+    b.committee_name = "농림축산식품해양수산위원회"
+    b.bill_stage = "소관위접수"
   end
   gov_bill2 = Bill.find_or_create_by!(bill_number: "2207522") do |b|
     b.title = "하도급거래 공정화에 관한 법률 일부개정법률안(정부)"
@@ -45,6 +47,8 @@ if Rails.env.development?
     b.assembly_bill_id = "ARC_D2L5R0Z1E1D5O1A1B0X2P5Z7E1S4O5"
     b.summary = "제안이유 및 주요내용 행정기관 소속 위원회를 효율적으로 운영하기 위하여 설치ㆍ운영 필요성이 줄어든 상습법위반사업자명단공표심의위원회를 폐지하고, 그 기능을 공정거래위원회가 수행하도록 하려는 것임."
     b.proposed_at = Date.new(2025, 1, 15)
+    b.committee_name = "정무위원회"
+    b.bill_stage = "소관위접수"
   end
 
   Proposal.find_or_create_by!(bill: gov_bill1, specific_proposer: gov_sponsor1)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,11 @@ if Rails.env.development?
     constituency: "전남 순천시광양시곡성군구례군갑",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771327.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771327.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19681001",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/KIMMOONSOO",
+    affiliated_committee: "교육위원회,예산결산특별위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -80,7 +84,11 @@ if Rails.env.development?
     constituency: "서울 서대문구갑",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771326.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771326.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19871030",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/KIMDONGAH",
+    affiliated_committee: "산업통상자원중소벤처기업위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -93,7 +101,11 @@ if Rails.env.development?
     constituency: "서울 은평구을",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771336.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771336.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19690805",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/KIMWOOYOUNG",
+    affiliated_committee: "과학기술정보방송통신위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -106,7 +118,11 @@ if Rails.env.development?
     constituency: "전남 해남군완도군진도군",
     election_count: "5선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771366.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771366.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19420605",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/PARKJIEWON",
+    affiliated_committee: "법제사법위원회,정보위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -119,7 +135,11 @@ if Rails.env.development?
     constituency: "경기 안산시병",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771369.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771369.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19650914",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/PARKHAECHEOL",
+    affiliated_committee: "환경노동위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -132,7 +152,11 @@ if Rails.env.development?
     constituency: "비례대표",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771376.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771376.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19671106",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/SEOMIHWA",
+    affiliated_committee: "국회운영위원회,보건복지위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -145,7 +169,11 @@ if Rails.env.development?
     constituency: "경기 성남시중원구",
     election_count: "재선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771269.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771269.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19690514",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/LEESOOJIN",
+    affiliated_committee: "12.29여객기참사진상규명과피해자및유가족의피해구제를위한특별위원회,보건복지위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -158,7 +186,11 @@ if Rails.env.development?
     constituency: "서울 양천구을",
     election_count: "재선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771115.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771115.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19580212",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/LEEYONGSUN",
+    affiliated_committee: "외교통일위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -171,7 +203,11 @@ if Rails.env.development?
     constituency: "충남 천안시을",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771412.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771412.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19650301",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/LEEJAEKWAN",
+    affiliated_committee: "산업통상자원중소벤처기업위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -184,7 +220,11 @@ if Rails.env.development?
     constituency: "경기 고양시을",
     election_count: "재선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771182.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771182.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19740220",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/HANJUNHO",
+    affiliated_committee: "국토교통위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end
@@ -197,7 +237,11 @@ if Rails.env.development?
     constituency: "경남 창원시성산구",
     election_count: "초선",
     latest_age: "22",
-    photo_url: "http://www.assembly.go.kr/photo/9771456.jpg"
+    photo_url: "http://www.assembly.go.kr/photo/9771456.jpg",
+    party_name: "더불어민주당",
+    birth_date: "19631029",
+    homepage_url: "https://www.assembly.go.kr/members/22nd/HUHSUNGMOO",
+    affiliated_committee: "2025 아시아태평양경제협력체(APEC) 정상회의 지원 특별위원회,산업통상자원중소벤처기업위원회,예산결산특별위원회"
   ) do |member|
     member.proposer_id = assembly_proposer.id
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,6 +54,15 @@ if Rails.env.development?
   Proposal.find_or_create_by!(bill: gov_bill1, specific_proposer: gov_sponsor1)
   Proposal.find_or_create_by!(bill: gov_bill2, specific_proposer: gov_sponsor2)
 
+  BillDetail.find_or_create_by!(bill_id: gov_bill1.id) do |detail|
+    detail.jurisdiction_examination_xml = "<committeeName>농림축산식품해양수산위원회</committeeName><presentDt/><procDt/><procResultCd/><submitDt>2025-03-21</submitDt>"
+    detail.law_title = "양봉산업의 육성 및 지원에 관한 법률"
+  end
+  BillDetail.find_or_create_by!(bill_id: gov_bill2.id) do |detail|
+    detail.jurisdiction_examination_xml = "<committeeName>정무위원회</committeeName><presentDt/><procDt/><procResultCd/><submitDt>2025-01-16</submitDt>"
+    detail.law_title = "하도급거래 공정화에 관한 법률"
+    detail.comm_memo_xml = "<commMemo>비용추계요구서 제출됨.</commMemo>"
+  end
 
   # 국회의원 제안주체 생성
   assembly_proposer = Proposer.find_by(proposer_type: "의원")
@@ -266,6 +275,12 @@ if Rails.env.development?
   Proposal.find_or_create_by!(bill: assembly_bill1, specific_proposer: assembly_proposer9, representative_proposal: false)
   Proposal.find_or_create_by!(bill: assembly_bill1, specific_proposer: assembly_proposer10, representative_proposal: false)
   Proposal.find_or_create_by!(bill: assembly_bill1, specific_proposer: assembly_proposer11, representative_proposal: false)
+
+  BillDetail.find_or_create_by!(bill_id: assembly_bill1.id) do |detail|
+    detail.jurisdiction_examination_xml = "<committeeName>정무위원회</committeeName><presentDt/><procDt/><procResultCd/><submitDt>2025-04-02</submitDt>"
+    detail.law_title = "갈등관리 및 공론화에 관한 법률"
+    detail.comm_memo_xml = "<commMemo>비용추계요구서 제출됨.</commMemo>"
+  end
 
   # TODO(@greenstar1151): 추후 정부입법예고 생성 필요
 end


### PR DESCRIPTION
## 작업 내용 
- 의안의 상세 내용을 저장하는 `BillDetail` 테이블을 생성했습니다.
- 외부 API에서 조회 기준이 되는 BILL_ID(`assembly_bill_id`)를 non-nullable하게 변경하였습니다. (Job의 파라미터 기준)

## 배경
- 법안 상세페이지 정보를 위해, 필요 데이터를 적재할 수 있는 DB 스키마 지원

## 필수 리뷰어
- @qndn3tp 

## 링크
- [공공데이터포털 국회사무처_의안 정보](https://www.data.go.kr/data/3037286/openapi.do)

## 기타 사항
- `BillDetail` 컬럼들은 이 화면과 거의 1:1 대응합니다:
  <img width="729" alt="image" src="https://github.com/user-attachments/assets/1da74e76-5455-468f-961c-ea418648ffe7" />
- 세부 필드를 나누는건 너무 과도하다고 생각해서, XML을 그대로 저장하는 컬럼이 있습니다. 이런 데이터의 경우 뷰에서 적절하게 처리해서 보여주는 작업이 필요합니다.
  - 각 필드의 구체적인 내용은 API 문서를 참고해주세요


## 체크 리스트
- db:seed 또는 db:reset 필요

## 희망 리뷰 완료 일  
- 2025.04.08(화)