### PR TITLE
chore: 리뷰어 자동 할당을 위한 CODEOWNERS 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @greenstar1151
+
+app/views @qndn3tp @Sumin6872


### PR DESCRIPTION
## 작업 내용 
- 깃헙에서 리뷰어 자동 할당을 위해 CODEOWNERS 파일을 추가합니다.

## 배경
- https://capstone2025-hq.slack.com/archives/C088TNAGSMT/p1744782736670309?thread_ts=1744774926.213509&cid=C088TNAGSMT

## 필수 리뷰어
- any

## 희망 리뷰 완료 일  
- 2025.04.16(수)
