### PR TITLE
feat: cron 스타일 잡 스케줄링 설정

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module LawnowWebapp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Asia/Seoul"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,12 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+production:
+  bulk_update_bill_info_periodic_job:
+    class: PeriodicJobs::BulkUpdateBillInfoPeriodicJob
+    schedule: 55 23 * * * # 매일 23시 55분에 실행
+  bulk_update_bill_committee_info_periodic_job:
+    class: PeriodicJobs::BulkUpdateBillCommitteeInfoPeriodicJob
+    schedule: 5 0 * * * # 매일 0시 5분에 실행
+  generate_llm_bill_summary_periodic_job:
+    class: PeriodicJobs::GenerateLlmBillSummaryPeriodicJob
+    # NOTE: Rate Limit 고려 필요, MAX_RECORDS_TO_PROCESS_PER_RUN 설정 참고
+    schedule: "*/15 * * * *" # 매 15분마다 실행
+    

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,12 +1,12 @@
 production:
   bulk_update_bill_info_periodic_job:
-    class: PeriodicJobs::BulkUpdateBillInfoPeriodicJob
-    schedule: 55 23 * * * # 매일 23시 55분에 실행
+    class: "PeriodicJobs::BulkUpdateBillInfoPeriodicJob"
+    schedule: "55 23 * * *" # 매일 23시 55분에 실행
   bulk_update_bill_committee_info_periodic_job:
-    class: PeriodicJobs::BulkUpdateBillCommitteeInfoPeriodicJob
-    schedule: 5 0 * * * # 매일 0시 5분에 실행
+    class: "PeriodicJobs::BulkUpdateBillCommitteeInfoPeriodicJob"
+    schedule: "5 0 * * *" # 매일 0시 5분에 실행
   generate_llm_bill_summary_periodic_job:
-    class: PeriodicJobs::GenerateLlmBillSummaryPeriodicJob
+    class: "PeriodicJobs::GenerateLlmBillSummaryPeriodicJob"
     # NOTE: Rate Limit 고려 필요, MAX_RECORDS_TO_PROCESS_PER_RUN 설정 참고
     schedule: "*/15 * * * *" # 매 15분마다 실행
     


### PR DESCRIPTION
## 작업 내용 
- 주기적인 실행이 필요한 Job들이 스케줄링되도록 설정하였습니다.

## 배경
- 프로덕션 환경에서 실제 데이터 채우기

## 필수 리뷰어
- any

## 링크
- 

## 기타 사항
- 레일즈 8부터 기본값으로 설정된 Solid Queue Job 백엔드 덕분에 간편하게 반복되는 잡을 스케줄링 할 수 있습니다. 더 자세한 내용은 [여기](https://guides.rubyonrails.org/active_job_basics.html#recurring-tasks)를 참고하시면 좋을 것 같습니다.

## 체크 리스트
- [x] 프로덕션 적용 후 Job 실행 확인

## 희망 리뷰 완료 일  
- 2025.04.18(금)