### PR TITLE
feat: 의안에서 제안 이유 및 주요 내용이 없을 때 LLM 요약을 노출하지 않고 요약을 생성하지 않도록 변경

### DIFF
--- a/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
+++ b/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
@@ -23,6 +23,7 @@ module PeriodicJobs
 
       # 아직 요약이 생성되지 않은 Bill만 가져오기
       bills = Bill.where(current_bill_summary_id: nil)
+                  .where.not(summary: nil)
                   .order(proposed_at: :desc)
                   .limit(MAX_RECORDS_TO_PROCESS_PER_RUN)
       Rails.logger.info("[#{self.class.name}] Bills to process: #{bills.pluck(:id).join(', ')}")

--- a/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
+++ b/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
@@ -23,7 +23,7 @@ module PeriodicJobs
 
       # 아직 요약이 생성되지 않은 Bill만 가져오기
       bills = Bill.where(current_bill_summary_id: nil)
-                  .where.not(summary: nil)
+                  .where.not(summary: [ nil, "" ])
                   .order(proposed_at: :desc)
                   .limit(MAX_RECORDS_TO_PROCESS_PER_RUN)
       Rails.logger.info("Bills to process: #{bills.pluck(:id).join(', ')}")

--- a/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
+++ b/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
@@ -15,7 +15,7 @@ module PeriodicJobs
 
     sig { void }
     def perform
-      Rails.logger.info("[#{self.class.name}] Starting job: fetching up to "+
+      Rails.logger.info("Starting job: fetching up to "+
                         "#{MAX_RECORDS_TO_PROCESS_PER_RUN} bills without summary")
       # 사용할 프롬프트 템플릿 조회 (없으면 예외)
       prompt = AiPromptTemplate.find_by!(name: DEFAULT_PROMPT_TEMPLATE)
@@ -26,10 +26,10 @@ module PeriodicJobs
                   .where.not(summary: nil)
                   .order(proposed_at: :desc)
                   .limit(MAX_RECORDS_TO_PROCESS_PER_RUN)
-      Rails.logger.info("[#{self.class.name}] Bills to process: #{bills.pluck(:id).join(', ')}")
+      Rails.logger.info("Bills to process: #{bills.pluck(:id).join(', ')}")
 
       bills.each do |bill|
-        Rails.logger.info("[#{self.class.name}] Processing Bill id=#{bill.id}, number=#{bill.bill_number}")
+        Rails.logger.info("Processing Bill id=#{bill.id}, number=#{bill.bill_number}")
         begin
           prompt_text = prompt.render_template(
             title:   bill.title,
@@ -49,16 +49,16 @@ module PeriodicJobs
             llm_model: DEFAULT_MODEL,
             summary_type: "llm"
           )
-          Rails.logger.info("[#{self.class.name}] Created BillSummary id=#{summary.id} for Bill id=#{bill.id}")
+          Rails.logger.info("Created BillSummary id=#{summary.id} for Bill id=#{bill.id}")
           # callback으로 current_bill_summary_id는 자동 갱신됨
 
           sleep DEFAULT_SLEEP_SECONDS
         rescue => e
-          Rails.logger.error("[#{self.class.name}] bill_id=#{bill.id} error=#{e.message}")
+          Rails.logger.error("Error: bill_id=#{bill.id} error=#{e.message}")
           next
         end
       end
-      Rails.logger.info("[#{self.class.name}] Finished job: processed #{bills.size} bills")
+      Rails.logger.info("Finished job: processed #{bills.size} bills")
     end
   end
 end

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -47,21 +47,23 @@
     </div>
   </div>
 
-  <!-- 법안 AI 요약 -->
-  <div class="bill-detail-container">
-    <div class="bill-detail-label">
-      <%= inline_svg("list", class: "list-icon") %>
-      AI 요약
+  <%# 제안 이유 및 주요 내용이 있을 경우만 AI 요약 섹션 표시 %>
+  <% if @bill.summary.present? %>
+    <!-- 법안 AI 요약 -->
+    <div class="bill-detail-container">
+      <div class="bill-detail-label">
+        <%= inline_svg("list", class: "list-icon") %>
+        AI 요약
+      </div>
+      <div class="bill-detail-content">
+        <% if @bill.current_bill_summary.present? %>
+          <%= render "ai_summary_accordion", current_bill_summary: @bill.current_bill_summary %>
+        <% else %>
+          요약 생성 중 ⏱️  곧 업데이트 될 거예요.
+        <% end %>
+      </div>
     </div>
-    <%# TODO: AI 요약 작업이 추가되면 수정 필요 %>
-    <div class="bill-detail-content">
-      <% if @bill.current_bill_summary.present? %>
-        <%= render "ai_summary_accordion", current_bill_summary: @bill.current_bill_summary %>
-      <% else %>
-        요약 생성 중 ⏱️  곧 업데이트 될 거예요.
-      <% end %>
-    </div>
-  </div>
+  <% end %>
 
   <!-- 법안 진행 상태 -->
   <div class="bill-detail-container">


### PR DESCRIPTION
## 작업 내용 
- 의안에서 제안 이유 및 주요 내용(`bill.summary`)이 없을 때,
  - LLM 요약을 노출하지 않고
  - 요약을 생성하지 않도록 변경

## 배경
- 의안이 "법률안"이 아닌 경우 제안 이유 및 주요 내용이 제공되지 않는 경우가 많아 LLM 요약이 필요하지 않음

## 필수 리뷰어
- @qndn3tp or @kimsj8912 

## 스크린샷
- <img width="1302" alt="image" src="https://github.com/user-attachments/assets/178b6f79-24c7-4c85-adec-062d4444332d" />
  
- 기획 변경이 있어 @kimsj8912 멘션드립니다.
  - 제안 이유 및 주요 내용이 없다면 AI 요약 섹션을 노출하지 않음


## 기타 사항
- production에서 bill.summary가 비어 있는데 bill.bill_summaries가 이미 생성된 레코드는 콘솔 작업으로 삭제 예정

## 희망 리뷰 완료 일  
- 2025.05.01(목)
