### PR TITLE
[LAWNOW-133] feat: AI 요약 마크다운에 스타일 적용

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @use "components/bill/bill_table";
 @use "components/bill_detail/bill_detail";
 @use "components/bill_detail/ai_summary_accordion";
+@use "components/bill_detail/ai_summary";
 @use "components/bill_detail/progress_bar";
 
 @use "components/login/login";

--- a/app/assets/stylesheets/components/bill_detail/_ai_summary.scss
+++ b/app/assets/stylesheets/components/bill_detail/_ai_summary.scss
@@ -1,0 +1,54 @@
+@use "../../colors/color_variables";
+@use "../../typography/typography" as *;
+
+// AI 요약 스타일
+
+// 제목
+.markdown h2 {
+    @include title-medium;
+    color: color_variables.$text-secondary-color;
+    margin-top: 10px;
+}
+
+// 왜 바뀌나요?, 마무리
+.markdown h3 {
+    @include title-small;
+    color: color_variables.$text-secondary-color;
+    margin-top: 10px;
+}
+  
+.markdown p {
+    @include body-large;
+    color: color_variables.$text-secondary-color;
+    margin-bottom: 20px;
+}
+ 
+// 개정 전/후 변화 테이블
+.markdown table {
+    width: 100%;
+    border-collapse: collapse; 
+    margin-top: 10px;
+    margin-bottom: 20px;
+}
+  
+.markdown th, .markdown td {
+    border: 1px solid #B9B9B9; 
+    padding: 0.75rem; 
+}
+
+.markdown td {
+    @include body-small;
+    color: color_variables.$text-secondary-color;
+}
+  
+.markdown th {
+    @include body-medium;
+    color: color_variables.$text-secondary-color;
+    background-color: #F0F0F0; 
+    text-align: center;
+}
+  
+// 첫 번째 열("구분")
+.markdown td:first-child {
+    font-weight: bold;
+}

--- a/app/assets/stylesheets/components/bill_detail/_ai_summary_accordion.scss
+++ b/app/assets/stylesheets/components/bill_detail/_ai_summary_accordion.scss
@@ -139,7 +139,6 @@
       @include body-small;
       width: 360px;
       color: color_variables.$text-ai-explain-color;
-      line-height: 1.6;
     }
   }
 

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -48,6 +48,7 @@ module MarkdownHelper
     renderer = Redcarpet::Render::HTML.new(render_options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
 
+    # 렌더링 된 마크다운에 "markdown" 스타일 적용
     content_tag :div,
             markdown.render(text).html_safe,
             class: "markdown"

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,7 +7,6 @@ require "redcarpet"
 module MarkdownHelper
   extend T::Sig
 
-
   sig { params(text: String, options: T::Hash[String, T.untyped]).returns(String) }
   def markdown(text, options = {})
     new_options = options.clone
@@ -49,6 +48,8 @@ module MarkdownHelper
     renderer = Redcarpet::Render::HTML.new(render_options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
 
-    markdown.render(text).html_safe
+    content_tag :div,
+            markdown.render(text).html_safe,
+            class: "markdown"
   end
 end


### PR DESCRIPTION
## 작업 내용 
- AI 요약 마크다운에 스타일을 적용했습니다.

## 배경
- 마크다운을 html로 보여줄 때, 스타일이 적용되어야합니다.

## 필수 리뷰어
- @greenstar1151, @Sumin6872 

## 스크린샷
<img width="606" alt="스크린샷 2025-05-05 오전 2 12 52" src="https://github.com/user-attachments/assets/50d2ea21-9e69-4617-9e4d-51edfa96ffd0" />

## 희망 리뷰 완료 일  
- **2024.05.05(월)**
