### PR TITLE
fix: LLM 게이트웨이 오류 수정 및 요약 Job 에러 리포팅 보강

### DIFF
--- a/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
+++ b/app/jobs/periodic_jobs/generate_llm_bill_summary_periodic_job.rb
@@ -55,6 +55,7 @@ module PeriodicJobs
           sleep DEFAULT_SLEEP_SECONDS
         rescue => e
           Rails.logger.error("Error: bill_id=#{bill.id} error=#{e.message}")
+          Sentry.capture_exception(e, extra: { bill_id: bill.id })
           next
         end
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@ bills:
   end_ord: 22
 
 litellm:
-  endpoint: "http://localhost:4000"
+  endpoint: "http://litellm:4000"
 
 # TODO: 추후 어드민에서 설정할 수 있도록 변경
 bill_summary:


### PR DESCRIPTION
## 작업 내용 
- 리모트 머신에서 LLM 게이트웨이 엔드포인트 오류 수정
- 법안 요약 Job 에러 리포팅 보강

## 배경
- 전에 deploy 브랜치에서 LiteLLM의 엔드포인트가 수정되었는데, 이게 메인 브랜치에 적용이 누락되어 있었습니다.
- rescue 블럭에서 에러를 처리하고 다른 작업이 없어서, 글로벌 Sentry까지 도달하지 못했습니다.

## 필수 리뷰어
- any

## 체크 리스트
- 배포 후 LLM Gateway 정상 동작 확인

## 희망 리뷰 완료 일  
- ASAP
