### PR TITLE
feat: 메인페이지 모바일 반응형 스타일 추가, 검색바 법안 태그 ui 변경

### DIFF
--- a/app/assets/stylesheets/components/_banner_search.scss
+++ b/app/assets/stylesheets/components/_banner_search.scss
@@ -27,14 +27,15 @@
   }
   
   input[type="text"] {
-    @include body-large; 
     border: none;
 
     @include mobile {
+      @include body-medium;
       width: 315px;
     }
 
     @include desktop {
+      @include body-large; 
       width: 660px;
     }
   }
@@ -47,7 +48,14 @@
 // 검색 버튼 스타일
 .search-button {
   @extend .search-icon;
-  padding-bottom: 16px;
+
+  @include mobile {
+    margin-left: 5px;
+  }
+
+  @include desktop {
+    margin-left: 10px;
+  }
 
   &:focus {
     outline: none;

--- a/app/assets/stylesheets/components/_law_categories.scss
+++ b/app/assets/stylesheets/components/_law_categories.scss
@@ -1,79 +1,93 @@
 @use "../colors/color_variables";
 @use "../typography/typography" as *;
 @use "../icons/divider_icon";
+@use "../layouts/responsive" as *;
 
 // 법안 카테고리 컴포넌트 스타일
-$law-components: (
-    all-comp: 81px,
-    starred-comp: 152px,
-    labor-humanrights-comp: 170px,
-    health-welfare-comp: 136px,
-    socialsecurity-national-comp: 200px,
-    economy-finance-comp: 103px,
-    informationcommunication-sciencetechnology-comp: 196px,
-    industry-agriculture-comp: 166px,
-    education-comp: 103px,
-    culture-sports-comp: 170px,
-    family-genderequality-comp: 151px,
-    diplomacy-unification-comp: 136px,
-    land-environment-comp: 136px,
-    disaster-climate-comp: 185px,
-    government-administration-comp: 136px,
-    legislative-judicial-comp: 200px
+$LAW_CATEGORIES: (
+    "all",
+    "starred",
+    "labor-humanrights",
+    "health-welfare",
+    "socialsecurity-national",
+    "economy-finance",
+    "informationcommunication-sciencetechnology",
+    "industry-agriculture",
+    "education",
+    "culture-sports",
+    "family-genderequality",
+    "diplomacy-unification",
+    "land-environment",
+    "disaster-climate",
+    "government-administration",
+    "legislative-judicial"
 );
 
 .law-component-layer {
     display: flex;
     max-width: 1652px;
-    padding: 20px;
-    
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
     margin: 0 auto;
-    gap: 10px;
+    
+    @include mobile {
+        gap: 5px;
+        padding: 15px;
+    }
+
+    @include desktop {
+        gap: 10px;
+        padding: 20px;
+    }
 }
 
 // 공통 스타일 정의
 %law-common-shape-component {
-    height: 57px;
-    min-height: 57px;
-    border-radius: 20px; 
-    border-width: 1px;
-    padding: 4px 25px;
-    gap: 10px;
-
+    width: auto;
     justify-content: center;
     display: flex;
     align-items: center;
-    box-sizing: border-box;
-    white-space: nowrap; // 자동 줄 바꿈이 안되게 설정 
-
     background: color_variables.$background-primary-color;
     border: 1px solid color_variables.$border-primary-color;
 
+    @include mobile {
+        // height: 35px;
+        // min-height: 35px;
+        height: 30px;
+        min-height: 30px;
+        border-radius: 12px; 
+        // padding: 8px 15px;
+        padding: 0px 10px;
+    }
+
+    @include desktop {
+        height: 57px;
+        min-height: 57px;
+        border-radius: 20px; 
+        padding: 4px 25px;
+    }
+
     &:focus, &:active, &:hover {
         outline: none !important;
-        border-color: color_variables.$border-primary-color !important;
+        border: 1px solid color_variables.$border-primary-color !important;
         box-shadow: none !important;
     }
 }
 
 // 각 컴포넌트의 스타일 생성
-@each $name, $width in $law-components {
-    .#{$name} {
+@each $name in $LAW_CATEGORIES {
+    .#{$name}-comp {
         @extend %law-common-shape-component;
-        width: $width;
     }
 }
 
 // 동적으로 선택된 탭에 대한 스타일 생성
-@each $name, $width in $law-components {
-    .#{$name}.active {
+@each $name in $LAW_CATEGORIES {
+    .#{$name}-comp.active {
         @extend %law-common-shape-component;
         border: 1px solid color_variables.$border-primary-color;
         background: color_variables.$surface-select-background-color;
-        width: $width;
     }
 }
 

--- a/app/assets/stylesheets/components/home/_category_select_search_bar.scss
+++ b/app/assets/stylesheets/components/home/_category_select_search_bar.scss
@@ -1,25 +1,8 @@
 @use "colors/color_variables";
 @use "../_law_categories.scss";
 @use "../../icons/remove_icon";
-@use "../../icons/search_icon";
 @use "../../typography/typography" as *;
-
-// 키워드 검색바 전체 영역 (입력창 + 카테고리 태그 포함)
-.keyword-search-bar {
-  width: 660px;
-  height: 58px;
-  padding: 0 16px;
-  gap: 8px;
-
-  margin: auto;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  box-sizing: border-box;
-  overflow: hidden;     // 가로 넘침 방지
-  position: relative;
-  border-bottom: 2px solid color_variables.$border-primary-color;
-}
+@use "../../layouts/responsive" as *;
 
 // 선택된 카테고리 태그가 보여지는 영역
 .selected-category-tag-container {
@@ -37,25 +20,15 @@
 
   // 실제 키워드 입력창
   input[type="text"] {
-    @include body-large;
-    flex: 1 1 auto;        // 공간 부족하면 줄어듦
-    min-width: 570px;
-    border: none;
-    height: 46px;
-    padding: 16px;
-    background: transparent;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-
-    // 포커스 시 테두리 제거
-    &:focus {
-      outline: none;
+    @include mobile {
+      height: 24px;
+      width: 100vw;
+      padding: 5px;
     }
 
-    &::placeholder {
-      color: color_variables.$text-tertiary-color;
-      opacity: 0.6;
+    @include desktop {
+      height: 46px;
+      padding: 16px;
     }
   }
 }
@@ -65,10 +38,19 @@
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
-  gap: 5px;
-  padding: 6px 15px;
-  border-radius: 20px;
   background-color: color_variables.$surface-primary-color;
+
+  @include mobile {
+    padding: 0px 10px;
+    border-radius: 15px;
+    height: 24px;
+  }
+
+  @include desktop {
+    gap: 5px;
+    padding: 6px 15px;
+    border-radius: 20px;
+  }
 
   span {
     @extend .law-common-text-component;
@@ -76,7 +58,6 @@
 
   .remove-button {
     @extend .remove-icon;
-    background: transparent;
     border: none;
     cursor: pointer;
     display: flex;
@@ -85,53 +66,45 @@
   }
 }
 
-// 검색 버튼 아이콘
-.keyword-search-button {
-  @extend .search-icon;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding-bottom: 16px;
-
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px color_variables.$background-primary-color;
-  }
-}
-
 // 실시간 검색어 영역
 .trending-keywords {
-  width: 660px;
-  margin: 15px auto 102px;
-  transform: translateX(20px);
   display: flex; 
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  color: color_variables.$text-secondary-color;
+
+  @include mobile {
+    width: 315px;
+    margin: 15px auto 50px;
+    gap: 5px;
+  }
+
+  @include desktop {
+    width: 660px;
+    margin: 15px auto 100px;
+    gap: 10px;
+  }
 
   .keyword-bubble {
-      background-color: color_variables.$surface-primary-color;
-      color: color_variables.$text-primary-color;
+    background-color: color_variables.$surface-primary-color;
+    color: color_variables.$text-primary-color;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-      width: 76px;
+    @include mobile {
+      height: 20px;
+      padding: 3px 13px;
+      border-radius: 15px;
+    }
+
+    @include desktop {
       height: 33px;
       padding: 6px 15px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 5px;
       border-radius: 20px;
-      white-space: nowrap;
-      flex-shrink: 0;
+    }
   }
 }
 
 .trending-keyword-text {
   @include caption-medium;
   font-weight: 700; 
-}
-
-.show-keywords {
-  display: flex !important;
 }

--- a/app/assets/stylesheets/components/home/_main_title.scss
+++ b/app/assets/stylesheets/components/home/_main_title.scss
@@ -1,14 +1,22 @@
 @use "colors/color_variables";
 @use "../../typography/typography" as *;
+@use "../../layouts/responsive" as *;
 
 .main-message-layer {
   text-align: center;
-  padding: 25px 410px 80px 410px;
+
+  @include mobile {
+    padding: 20px;
+  }
+
+  @include desktop {
+    padding: 25px 20px 80px 20px;
+  }
 }
 
 .headline-text {
-  @include headline-large;
-  color: color_variables.$text-primary-color; // 필요에 따라 색상 지정
+  @include headline-medium;
+  color: color_variables.$text-primary-color;
 }
 
 .title-text {

--- a/app/assets/stylesheets/icons/_divider_icon.scss
+++ b/app/assets/stylesheets/icons/_divider_icon.scss
@@ -1,12 +1,13 @@
 @use "../colors/color_variables";
-
-$icon-width: 36px; 
-$icon-height: 0px; 
+@use "../layouts/responsive" as *;
 
 .divider-icon {
-    width: $icon-width;
-    height: $icon-height;
-    opacity: 0.35;
-    flex-shrink: 0;
-    stroke: color_variables.$border-primary-color;
+    @include mobile {
+        width: 5px; 
+        height: 25px; 
+    }
+    @include desktop {
+        width: 36px; 
+        height: 45px; 
+    }
 }

--- a/app/assets/stylesheets/icons/_remove_icon.scss
+++ b/app/assets/stylesheets/icons/_remove_icon.scss
@@ -1,10 +1,15 @@
 @use "../colors/color_variables";
-
-$icon-width: 24px; 
-$icon-height: 24px; 
+@use "../layouts/responsive" as *;
 
 .remove-icon {
-  width: $icon-width;
-  height: $icon-height;
   color: color_variables.$text-tertiary-color;
+
+  @include mobile {
+    width: 12px; 
+    height: 12px; 
+  }
+  @include desktop {
+    width: 24px; 
+    height: 24px; 
+  }
 }

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["selectedCategory", "input"]
-
+  
   connect() {
     // 선택된 탭을 Set으로 관리
     this.selectedTabs = new Set()
@@ -51,6 +51,33 @@ export default class extends Controller {
     
     // 태그 표시 업데이트
     this.updateTagsDisplay()
+    // placeholder 업데이트
+    this.updatePlaceholder()
+  }
+
+  submitSingleTab(e) {
+    e.preventDefault()
+    const tab = e.currentTarget.dataset.tab
+  
+    this.selectedTabs.clear()
+  
+    const baseUrl = "/bills"
+  
+    // 전체 탭일 경우 쿼리스트링 없이 이동
+    if (tab === "all") {
+      window.location.href = baseUrl
+      return
+    }
+  
+    // 관심법안은 별도 처리
+    if (tab === "starred") {
+      window.location.href = `${baseUrl}?starred=true`
+      return
+    }
+  
+    const params = new URLSearchParams()
+    params.set("tab", tab)
+    window.location.href = `${baseUrl}?${params.toString()}`
   }
 
   // 모든 태그 표시 업데이트
@@ -61,10 +88,7 @@ export default class extends Controller {
     this.clearAllTags()
     
     // 선택된 탭이 없으면 종료 및 placeholder 업데이트
-    if (this.selectedTabs.size === 0) {
-      this.updatePlaceholder()
-      return
-    }
+    if (this.selectedTabs.size === 0) return
     
     const tabsArray = Array.from(this.selectedTabs)
     
@@ -80,7 +104,7 @@ export default class extends Controller {
     if (remainingCount > 0) {
       this.addMoreTag(remainingCount)
     }
-    
+
     // placeholder 업데이트
     this.updatePlaceholder()
   }

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -18,9 +18,10 @@ export default class extends Controller {
     tabsFromUrl.forEach(tab => {
       if (["all", "starred"].includes(tab)) return
       this.selectedTabs.add(tab)
-      const label = this.findLabelForTab(tab)
-      if (label) this.addTag(tab, label)
     })
+    
+    // 태그 표시 업데이트
+    this.updateTagsDisplay()
   }
 
   toggleCategory(e) {
@@ -33,7 +34,6 @@ export default class extends Controller {
       // 이미 선택된 상태면 해제
       button.classList.remove("active")
       this.selectedTabs.delete(tab)
-      this.removeTag(tab)
     } else {
       // "전체"나 "내 관심법안"이 선택된 상태라면 해제
       document.querySelectorAll(".law-category-button.active").forEach(btn => {
@@ -41,49 +41,61 @@ export default class extends Controller {
         if (["all", "starred"].includes(key)) {
           btn.classList.remove("active")
           this.selectedTabs.delete(key)
-          this.removeTag(key)
         }
       })
 
-      // 선택된 탭 추가 및 태그 표시
+      // 선택된 탭 추가
       button.classList.add("active")
       this.selectedTabs.add(tab)
-      this.addTag(tab, label)
     }
+    
+    // 태그 표시 업데이트
+    this.updateTagsDisplay()
   }
 
-  submitSingleTab(e) {
-    e.preventDefault()
-    const tab = e.currentTarget.dataset.tab
-  
-    this.selectedTabs.clear()
-  
-    const baseUrl = "/bills"
-  
-    // 전체 탭일 경우 쿼리스트링 없이 이동
-    if (tab === "all") {
-      window.location.href = baseUrl
-      return
-    }
-  
-    // 관심법안은 별도 처리
-    if (tab === "starred") {
-      window.location.href = `${baseUrl}?starred=true`
-      return
-    }
-  
-    const params = new URLSearchParams()
-    params.set("tab", tab)
-    window.location.href = `${baseUrl}?${params.toString()}`
-  }  
-
-  addTag(tab, label) {
+  // 모든 태그 표시 업데이트
+  updateTagsDisplay() {
     if (!this.hasSelectedCategoryTarget) return
-
-    // 이미 해당 태그가 표시되어 있다면 중복 추가하지 않음
-    if (this.selectedCategoryTarget.querySelector(`[data-tab="${tab}"]`)) return
-
-    // 태그 요소 생성 및 검색바에 추가
+    
+    // 기존 태그와 더보기 태그 모두 제거
+    this.clearAllTags()
+    
+    // 선택된 탭이 없으면 종료 및 placeholder 업데이트
+    if (this.selectedTabs.size === 0) {
+      this.updatePlaceholder()
+      return
+    }
+    
+    const tabsArray = Array.from(this.selectedTabs)
+    
+    // 지정된 개수만큼 태그 표시
+    for (let i = 0; i < Math.min(1, tabsArray.length); i++) {
+      const tab = tabsArray[i]
+      const label = this.findLabelForTab(tab)
+      if (label) this.createTagElement(tab, label)
+    }
+    
+    // 더 보기 태그 추가 (남은 태그가 있는 경우)
+    const remainingCount = tabsArray.length - 1
+    if (remainingCount > 0) {
+      this.addMoreTag(remainingCount)
+    }
+    
+    // placeholder 업데이트
+    this.updatePlaceholder()
+  }
+  
+  // placeholder 업데이트
+  updatePlaceholder() {
+    if (this.selectedTabs.size > 0) {
+      this.inputTarget.placeholder = ""
+    } else {
+      this.inputTarget.placeholder = "검색어를 입력해주세요"
+    }
+  }
+  
+  // 태그 요소 생성
+  createTagElement(tab, label) {
     const tag = document.createElement("div")
     tag.className = "selected-category-tag"
     tag.dataset.tab = tab
@@ -92,12 +104,33 @@ export default class extends Controller {
       <span>${label}</span>
     `
     this.selectedCategoryTarget.insertBefore(tag, this.inputTarget)
+    return tag
   }
-
-  removeTag(tab) {
-    // 특정 탭에 해당하는 태그를 검색바에서 제거
-    const tag = this.selectedCategoryTarget.querySelector(`.selected-category-tag[data-tab="${tab}"]`)
-    if (tag) tag.remove()
+  
+  // +N 태그 추가
+  addMoreTag(count) {
+    const moreTag = document.createElement("div")
+    moreTag.className = "selected-category-tag more-count-tag"
+    moreTag.innerHTML = `<span>+ ${count}</span>`
+    moreTag.addEventListener('click', () => this.showAllTags())
+    this.selectedCategoryTarget.insertBefore(moreTag, this.inputTarget)
+  }
+  
+  // 모든 태그 보여주기
+  showAllTags() {
+    this.clearAllTags()
+    
+    // 모든 선택된 탭을 태그로 표시
+    this.selectedTabs.forEach(tab => {
+      const label = this.findLabelForTab(tab)
+      if (label) this.createTagElement(tab, label)
+    })
+  }
+  
+  // 모든 태그 제거
+  clearAllTags() {
+    const existingTags = this.selectedCategoryTarget.querySelectorAll('.selected-category-tag')
+    existingTags.forEach(tag => tag.remove())
   }
 
   removeCategory(e) {
@@ -105,8 +138,10 @@ export default class extends Controller {
     const tab = e.target.dataset.tab
     const button = document.querySelector(`.law-category-button[data-tab="${tab}"]`)
     if (button) button.classList.remove("active")
-    this.removeTag(tab)
     this.selectedTabs.delete(tab)
+    
+    // 태그 표시 업데이트
+    this.updateTagsDisplay()
   }
 
   goToSearch(e) {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,8 +23,10 @@
   </div>
 </nav>
 
+<!-- 법안 카테고리 -->
 <% active_tabs = parsed_active_tabs %>
 
+<!-- 메인페이지 법안 검색바 -->
 <form data-controller="category-search" data-action="submit->category-search#goToSearch">
   <%= render "shared/law_categories", active_tabs: active_tabs, context: :search %>
 
@@ -36,21 +38,17 @@
     </div>
   </div>
 
-  <div class="keyword-search-bar">
+  <div class="search-bar">
     <div id="selected-category"
          class="selected-category-tag-container"
          data-category-search-target="selectedCategory">
-      <% Array(params[:tab]).reject { |t| %w[all starred].include?(t) }.each do |tab| %>
-        <%= hidden_field_tag "tab[]", tab %>
-      <% end %>
-
       <%= text_field_tag :q, params[:q],
-            placeholder: "검색어를 입력해주세요.",
+            placeholder: "검색어를 입력해주세요",
             data: { "category-search-target": "input" } %>
     </div>
 
     <button type="submit"
-            class="keyword-search-button"
+            class="search-button"
             data-action="click->category-search#goToSearch">
       <%= inline_svg("search", class: "search-icon") %>
     </button>

--- a/app/views/shared/_law_categories.html.erb
+++ b/app/views/shared/_law_categories.html.erb
@@ -49,7 +49,7 @@
 
     <% if key == "all" || key == "starred" %>
       <div class="law-divider">
-        <%= inline_svg("divider", class: "law-divider-icon") %>
+        <%= inline_svg("divider", class: "divider-icon") %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## 작업 내용 
- 태그가 2개 이상일 때 첫 번째 태그만 표시하고 나머지는 "+ N" 형식으로 요약 표시하도록 ui를 변경했습니다.
- 선택된 태그가 있을 때, 입력 필드 플레이스홀더를 숨기도록 했습니다.
- 메인페이지(HOT이슈 제외)에 모바일 반응형 스타일을 추가했습니다.
- 기타 코드를 리팩토링했습니다.

## 배경
- 메인페이지 검색바 태그 ui 디자인 변경이 있었습니다.
- 반응형 웹을 적용할 필요가 있습니다.

## 필수 리뷰어
- @Sumin6872, @kimsj8912 

## 스크린샷
<img width="387" alt="스크린샷 2025-05-12 오후 11 17 01" src="https://github.com/user-attachments/assets/1a5989e6-07cd-427c-aba9-809f8ad65a22" />
<img width="387" alt="스크린샷 2025-05-12 오후 11 33 04" src="https://github.com/user-attachments/assets/c811dbe2-ddca-4f47-a243-d2477671425b" />

## 기타 사항
- HOT이슈 법안은 수민님이 작업중이셔서, 수정하지 않았는데, 추후 반응형 웹 스타일 수정이 필요합니다.

## 희망 리뷰 완료 일  
- **2025.05.13(화)**
