### PR TITLE
fix: kamal gem 버전 고정

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -14,7 +14,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Install required gems
-        run: gem install kamal ed25519 x25519
+        run: gem install kamal:2.6.0 ed25519 x25519
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@v1

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "solid_cable"
 gem "bootsnap", require: false
 
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false
+gem "kamal", "~> 2.6", require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,9 +137,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     deep_merge (1.2.2)
-    dotenv (3.1.7)
+    dotenv (3.1.8)
     drb (2.2.1)
-    ed25519 (1.3.0)
+    ed25519 (1.4.0)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)
@@ -208,13 +208,13 @@ GEM
     json (2.10.1)
     jwt (2.10.1)
       base64
-    kamal (2.5.2)
+    kamal (2.6.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
       concurrent-ruby (~> 1.2)
       dotenv (~> 3.1)
-      ed25519 (~> 1.2)
+      ed25519 (~> 1.4)
       net-ssh (~> 7.3)
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
@@ -576,7 +576,7 @@ DEPENDENCIES
   importmap-rails
   inline_svg
   jbuilder
-  kamal
+  kamal (~> 2.6)
   liquid (~> 5.8)
   omniauth (~> 2.1)
   omniauth-naver (~> 0.2.0)


### PR DESCRIPTION
## 작업 내용 
- 프로젝트와 CI에서 사용하는 kamal gem 버전을 고정했습니다.

## 배경
- CI와 프로젝트 환경의 버전 불일치로 인한 배포 실패
  - https://github.com/kookmin-sw/capstone-2025-01/actions/runs/15036977112
  - 프로젝트에서 사용하고 있던 kamal 2.5.2는 kamal-proxy 0.8.4를 사용하지만, kamal 2.6.0은 kamal-proxy 0.9.0을 사용하여 배포 실패 발생

## 필수 리뷰어
- any

## 기타 사항
- 로컬에서 이미 kamal 2.6.0 설치하고 `kamal proxy reboot` 해서 아마 워크플로우는 지금도 제대로 돌 거예요.

## 희망 리뷰 완료 일  
- ASAP
