### PR TITLE
fix: 카테고리 필터 관련 백엔드 버그 수정 및 프론트엔드에 디바운싱 적용 

### DIFF
--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -15,7 +15,10 @@ class BillsController < ApplicationController
 
     @bills = @bills.by_title(params[:q])
                    .by_bill_type(bill_type_param)
-                   .where(category: @tabs) if @tabs.any?
+
+    if @tabs.any?
+      @bills = @bills.where(category: @tabs)
+    end
 
     @pagy, @bills = pagy(@bills.order(proposed_at: :desc, bill_number: :desc))
 

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -3,19 +3,11 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["selectedCategory", "input"]
 
-  // Debounce utility
-  debounce(func, wait) {
-    let timeout
-    return (...args) => {
-      clearTimeout(timeout)
-      timeout = setTimeout(() => func.apply(this, args), wait)
-    }
-  }
-
-
   connect() {
+    // 카테고리 필터를 위한 디바운싱 타임아웃 오브젝트 설정
+    this.debounceTimeout = null;
     // 디바운싱된 검색 메서드
-    this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 500)
+    this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 1000)
 
     // 선택된 탭을 Set으로 관리
     this.selectedTabs = new Set()
@@ -37,6 +29,27 @@ export default class extends Controller {
     this.updateTagsDisplay()
     // placeholder 업데이트
     this.updatePlaceholder()
+  }
+
+  // Debounce utility
+  debounce(func, wait) {
+    // This method will now use `this.debounceTimeout` to store the timeout ID.
+    // This makes the timeout ID accessible to other methods like disconnect().
+    // Note: This assumes this specific `debounceTimeout` property is dedicated
+    // to the single debounced function created in this controller.
+    return (...args) => {
+      clearTimeout(this.debounceTimeout)
+      this.debounceTimeout = setTimeout(() => {
+        func.apply(this, args)
+      }, wait)
+    }
+  }
+
+  disconnect() {
+    if (this.debounceTimeout) {
+      clearTimeout(this.debounceTimeout);
+      this.debounceTimeout = null;
+    }
   }
 
   toggleCategory(e) {

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -221,10 +221,7 @@ export default class extends Controller {
     if (button) button.classList.remove("active")
     this.selectedTabs.delete(tab)
     
-    // 태그, URL 업데이트
-    this.updateTagsDisplay()
-    this.updateURL()
-    this.debouncedGoToSearch(e)
+    this.categoryStrategy.onCategoryToggle(this, e);
   }
 
   // URL 업데이트 메서드

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     // 카테고리 필터를 위한 디바운싱 타임아웃 오브젝트 설정
     this.debounceTimeout = null;
     // 디바운싱된 검색 메서드
-    this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 1000)
+    this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 500)
 
     // 선택된 탭을 Set으로 관리
     this.selectedTabs = new Set()

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -1,20 +1,27 @@
 import { Controller } from "@hotwired/stimulus"
 
 export class NoRedirectStrategy {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl;
+  }
   onCategoryToggle(controller, event) {
     // 필터 UI만 갱신, URL 이동 없음
     controller.updateTagsDisplay();
     controller.updatePlaceholder();
-    controller.updateURL();
+    controller.updateURL(this.baseUrl);
+    // URL 이동 없음
   }
 }
 
 export class RedirectStrategy {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl;
+  }
   onCategoryToggle(controller, event) {
     // 필터 변경 시 URL 이동
     controller.updateTagsDisplay();
     controller.updatePlaceholder();
-    controller.updateURL();
+    controller.updateURL(this.baseUrl);
     controller.debouncedGoToSearch(event);
   }
 }
@@ -29,12 +36,14 @@ export default class extends Controller {
     this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 500)
 
     // 전략 결정: 루트(/)면 NoRedirect, /bills면 Redirect
+    let baseUrl = "/bills";
     if (window.location.pathname === "/") {
-      this.categoryStrategy = new NoRedirectStrategy();
+      baseUrl = "/";
+      this.categoryStrategy = new NoRedirectStrategy(baseUrl);
     } else if (window.location.pathname.startsWith("/bills")) {
-      this.categoryStrategy = new RedirectStrategy();
+      this.categoryStrategy = new RedirectStrategy(baseUrl);
     } else {
-      this.categoryStrategy = new NoRedirectStrategy(); // 기본값
+      this.categoryStrategy = new NoRedirectStrategy(baseUrl); // 기본값
     }
 
     // 선택된 탭을 Set으로 관리
@@ -225,8 +234,7 @@ export default class extends Controller {
   }
 
   // URL 업데이트 메서드
-  updateURL() {
-    const baseUrl = "/bills"
+  updateURL(baseUrl) {
     const params = new URLSearchParams(window.location.search)
     
     // 기존 tab[] 파라미터 모두 제거

--- a/app/javascript/controllers/category_search_controller.js
+++ b/app/javascript/controllers/category_search_controller.js
@@ -2,8 +2,21 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["selectedCategory", "input"]
-  
+
+  // Debounce utility
+  debounce(func, wait) {
+    let timeout
+    return (...args) => {
+      clearTimeout(timeout)
+      timeout = setTimeout(() => func.apply(this, args), wait)
+    }
+  }
+
+
   connect() {
+    // 디바운싱된 검색 메서드
+    this.debouncedGoToSearch = this.debounce(this.goToSearch.bind(this), 500)
+
     // 선택된 탭을 Set으로 관리
     this.selectedTabs = new Set()
 
@@ -57,6 +70,7 @@ export default class extends Controller {
     this.updatePlaceholder()
     // URL 업데이트
     this.updateURL()
+    this.debouncedGoToSearch(e)
   }
 
   submitSingleTab(e) {
@@ -175,6 +189,7 @@ export default class extends Controller {
     // 태그, URL 업데이트
     this.updateTagsDisplay()
     this.updateURL()
+    this.debouncedGoToSearch(e)
   }
 
   // URL 업데이트 메서드


### PR DESCRIPTION
## 작업 내용 
- `@tabs.any?` 조건이 전체 필터링에 잘못 걸려 있던 문제를 수정했습니다.
  - 카테고리 선택이 되어 있어야 검색어(q)가 동작하는 문제가 있었는데 독립적으로 동작하도록 수정
- FE에서 카테고리 필터를 선택한 즉시 법안 목록이 업데이트되도록 변경했습니다.
  - 그에 따라 변경 이벤트마다 요청이 날라가게 되는데, 이때 부하를 줄이기 위해 카테고리 필터에 디바운싱을 적용하였습니다.

## 배경
- 검색 버그 수정
- 사용성 개선 (필터의 즉시 적용) / 최적화 (디바운싱)

## 필수 리뷰어
- @qndn3tp 

## 기타 사항
- 디바운싱 딜레이를 일단 500ms로 잡아놨는데, 더 적절한 값이 있으면 추천 부탁드립니다!

## 희망 리뷰 완료 일  
- 2025.05.15(목)
