### PR TITLE
fix: 법안 상태값 실제 데이터에 맞게 수정

### DIFF
--- a/app/helpers/bills_view_helper.rb
+++ b/app/helpers/bills_view_helper.rb
@@ -2,7 +2,7 @@ module BillsViewHelper
   def bill_steps(bill)
     base_steps = Bill.steps[0..2]
     final_step = bill.current_status_key == :discarded ?
-                   Bill::STATUS_LABELS[:discarded] : Bill::STATUS_LABELS[:executed]
+                   BillStatus::STATUS_LABELS[:discarded] : BillStatus::STATUS_LABELS[:executed]
     base_steps + [ final_step ]
   end
 
@@ -19,7 +19,7 @@ module BillsViewHelper
     next_step = steps[index + 1]
 
     if bill.current_status == next_step || current_index > index
-      next_step == Bill::STATUS_LABELS[:discarded] ? "step-line danger" : "step-line active"
+      next_step == BillStatus::STATUS_LABELS[:discarded] ? "step-line danger" : "step-line active"
     else
       "step-line"
     end

--- a/app/models/concerns/bill_status.rb
+++ b/app/models/concerns/bill_status.rb
@@ -4,18 +4,18 @@ module BillStatus
   STATUS_KEYS = %i[received reviewing decided executed discarded].freeze
 
   STATUS_LABELS = {
-    received: "접수",
+    received:  "접수",
     reviewing: "검토",
-    decided: "결정",
-    executed: "시행",
+    decided:   "결정",
+    executed:  "시행",
     discarded: "중단"
   }.freeze
 
   STATUS_EMOJIS = {
-    received: "📥",
+    received:  "📥",
     reviewing: "🤔",
-    decided: "📦",
-    executed: "✅",
+    decided:   "📦",
+    executed:  "✅",
     discarded: "❌"
   }.freeze
 
@@ -37,16 +37,16 @@ module BillStatus
       end
     end
 
-    def current_status         = STATUS_LABELS[current_status_key]
-    def status_emoji          = STATUS_EMOJIS[current_status_key]
-    def status_css_class      = "status-#{current_status_key}"
-    def status_text_class     = "text-#{current_status_key}"
+    def current_status    = STATUS_LABELS[current_status_key]
+    def status_emoji      = STATUS_EMOJIS[current_status_key]
+    def status_css_class  = "status-#{current_status_key}"
+    def status_text_class = "text-#{current_status_key}"
 
-    def received?             = current_status_key == :received
-    def reviewing?            = current_status_key == :reviewing
-    def decided?              = current_status_key == :decided
-    def executed?             = current_status_key == :executed
-    def rejected?             = current_status_key == :discarded
+    def received?   = current_status_key == :received
+    def reviewing?  = current_status_key == :reviewing
+    def decided?    = current_status_key == :decided
+    def executed?   = current_status_key == :executed
+    def rejected?   = current_status_key == :discarded
   end
 
   class_methods do

--- a/app/models/concerns/bill_status.rb
+++ b/app/models/concerns/bill_status.rb
@@ -22,12 +22,18 @@ module BillStatus
   included do
     def current_status_key
       case bill_stage
-      when "소관위접수"                      then :received
-      when "소관위심사중", "법사위심사중"     then :reviewing
-      when "의결", "국회통과", "법사위의결"   then :decided
-      when "공포", "시행"                    then :executed
-      when "폐기"                            then :discarded
-      else :received
+      when "접수", "소관위접수"
+        :received
+      when "소관위심사보고", "소관위심사", "체계자구심사", "본회의부의안건", "재의요구"
+        :reviewing
+      when "본회의의결", "정부이송", "재의(부결)", "재의(가결)"
+        :decided
+      when "공포"
+        :executed
+      when "대안반영폐기", "수정안반영폐기", "철회"
+        :discarded
+      else
+        :received
       end
     end
 

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -31,7 +31,6 @@
             <%# 국회의원 전체목록 API에서 정당을 제공하지 않아 현재는 이름을 표시 중이나, 추후 필드 추가 후 수정 예정 %>
             <%= bill.proposals.first&.specific_proposer&.display_name || "" %>
           </div>
-          <%# TODO: 법안 상태 추가 필요 %>
           <div class="bill-tag-status <%= bill.status_css_class %>">
             <%= bill.status_emoji %>
             <%= bill.current_status %>


### PR DESCRIPTION
## 작업 내용 
- 의안 상태 (`Bill.bill_stage`)의 값을 보고 상태를 맵핑하는 `current_status_key` 함수를 실제 데이터에 맞게 업데이트했습니다.
- 기타 코드 수정

## 배경
- 법안 목록에서 법안의 상태, 상세 페이지에서 프로그레스바가 제대로 표시되지 않는 문제

## 필수 리뷰어
- @kimsj8912 

## 스크린샷
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/45c8aafa-15eb-487d-8bd7-f67faeade013" />


## 기타 사항
- `current_status_key` 맵핑은 예전에 논의한 내용 기반으로 잡아놓았는데, 한번 검토해주시고 더 좋은 분류 방향 있다면 말씀해주세요!
- 최신(2025.05.15) 데이터 기준 모든 상태값은 다음과 같습니다:
  - `Bill.all.pluck(:bill_stage).uniq`
    ```
    [nil, "공포", "대안반영폐기", "본회의부의안건", "본회의의결", "소관위심사", "소관위심사보고", "소관위접수", "수정안반영폐기", "재의(가결)", "재의(부결)", "재의요구", "접수", "정부이송", "철회", "체계자구심사"]
    ```

## 희망 리뷰 완료 일  
- 2025.05.16(금)
