### PR TITLE
feat: 법안 목록페이지 카드 내용을 ai 요약으로 변경

### DIFF
--- a/app/helpers/bill_view_helper.rb
+++ b/app/helpers/bill_view_helper.rb
@@ -1,6 +1,7 @@
 module BillViewHelper
   include TabParamsParser
 
+  # 법안 목록페이지: 법안 카테고리 버튼 생성
   def law_category_button(tab, options = {})
     disabled      = options[:disabled] || false
     context       = options[:context] || :search
@@ -41,11 +42,35 @@ module BillViewHelper
     "people-power" => "국민의 힘",
     "rebuilding-korea" => "조국혁신당"
   }.freeze
-
+  # 법안 목록페이지: 정당 카테고리 버튼 생성
   def political_party_tab(party)
     party_name = PARTY_CATEGORIES[party]
     content_tag(:div, class: "#{party}-shape") do
       content_tag(:div, party_name, class: "#{party}-text")
     end
+  end
+
+  # 법안 목록페이지: 법안 카드 내용(ai 요약 제목 / 법안 요약)
+  def bill_summary_content(bill)
+    if bill.current_bill_summary.present?
+      extract_h2_section(bill.current_bill_summary.content)
+    else
+      summary_text(bill.summary)
+    end
+  end
+
+  private
+
+  def extract_h2_section(content)
+    return "" if content.blank?
+
+    h2_section = content.split(/^###/).first
+    h2_section&.gsub(/^##\s*/, "")&.strip || ""
+  end
+
+  def summary_text(summary)
+    return "" if summary.blank?
+
+    summary.gsub(/\A(?:제안이유 및 주요내용|제안이유)[:\s]*/, "")
   end
 end

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -47,19 +47,19 @@
         </div>
       </div>
       <div class="bill-description">
-        <%# TODO: AI 요약 지원 추가 필요 %>
-        <span class="mobile-only">
-          <%= truncate(
-            (bill.summary || "").gsub(/\A(?:제안이유 및 주요내용|제안이유)[:\s]*/, ""),
-            length: 80
-          ) %>
-        </span>
-        <span class="desktop-only">
-          <%= truncate(
-            (bill.summary || "").gsub(/\A(?:제안이유 및 주요내용|제안이유)[:\s]*/, ""),
-            length: 120
-          ) %>
-        </span>
+        <% if bill.summary.present? %>
+            <!-- 법안 카드 내용(ai 요약 제목 / 법안 요약) -->
+            <% if bill.current_bill_summary.present? %>
+              <%= simple_format(bill_summary_content(bill)) %>
+            <% else %>
+              <span class="mobile-only">
+                <%= truncate(bill_summary_content(bill), length: 80) %>
+              </span>
+              <span class="desktop-only">
+                <%= truncate(bill_summary_content(bill), length: 120) %>
+              </span>
+            <% end %>
+        <% end %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## 작업 내용 
- 법안 목록페이지에 표시되는 카드 내용을 ai 요약의 제목 부분으로 변경했습니다.
- ai 요약이 생성되지 않은 경우, 기존 방법대로 원문 요약을 보여주도록 했습니다.

## 배경
- 노션에서 제기된 문제에 대해 기존 법안 카드 내용을 ai요약 제목을 보여주도록 변경할 필요성을 느꼈습니다.
<img width="692" alt="스크린샷 2025-05-28 오후 5 08 44" src="https://github.com/user-attachments/assets/06059995-b11b-44a9-b9ec-6a895738080f" />


## 필수 리뷰어
- @kimsj8912 

## 스크린샷
다음과 같이 ai 요약 제목이 있는 경우
<img width="1157" alt="스크린샷 2025-05-28 오후 5 04 08" src="https://github.com/user-attachments/assets/74a27f95-dacc-4a85-a52d-c970c532d566" />

ai 요약 제목을 보여줍니다.
두번째 법안은 아직 요약이 생성되지 않은 것으로, 기존과 같이 원문을 보여줍니다.
<img width="1154" alt="스크린샷 2025-05-28 오후 5 04 00" src="https://github.com/user-attachments/assets/302f9b6b-d8ce-4e82-9264-182fee6d8318" />

## 희망 리뷰 완료 일  
- **ASAP**
